### PR TITLE
Ensure new calendar events appear in week view

### DIFF
--- a/script_100_percent_working.js
+++ b/script_100_percent_working.js
@@ -1312,6 +1312,8 @@ document.addEventListener('DOMContentLoaded', () => {
     if (!calendarMain) return;
     if (calendarState.view === 'week') {
       renderWeekView(calendarMain);
+      // Render any events for the week view so newly created events appear
+      renderEvents('week', null, calendarMain);
     } else {
       renderMonthView(calendarMain);
     }


### PR DESCRIPTION
## Summary
- Render week view events after building the calendar grid so newly saved events display immediately

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689609a1c2008322b3fb1556ece55621